### PR TITLE
Add `shellcheck` for basic validation of shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master

--- a/install/wiggum.sh
+++ b/install/wiggum.sh
@@ -7,6 +7,7 @@
 
 set -e
 
+# shellcheck disable=SC1091
 source .wiggum
 
 if [[ -z "${WIGGUM_PATH}" ]] || [[ "${WIGGUM_PATH}" == "wiggum-official" ]];
@@ -14,16 +15,16 @@ then
   if [[ -z "${VERSION_OVERRIDE}" ]] || [[ "${VERSION_OVERRIDE}" == "latest" ]];
   then
     echo "Checking latest version of Wiggum..."
-    WIGGUM_VERSION=`curl -fsSL https://raw.githubusercontent.com/homes-com-au/wiggum/master/version/latest`
+    WIGGUM_VERSION=$(curl -fsSL https://raw.githubusercontent.com/homes-com-au/wiggum/master/version/latest)
   else
     echo "Wiggum is overriding your version to ${VERSION_OVERRIDE}"
     WIGGUM_VERSION=$VERSION_OVERRIDE
   fi
 
   echo "Fetching version ${WIGGUM_VERSION}..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/homes-com-au/wiggum/master/version/${WIGGUM_VERSION}/wiggum.sh)"
+  /bin/bash -c "$(curl -fsSL "https://raw.githubusercontent.com/homes-com-au/wiggum/master/version/${WIGGUM_VERSION}/wiggum.sh")"
 else
   echo "Wiggum is using ${WIGGUM_PATH}"
-  . $WIGGUM_PATH
+  # shellcheck disable=SC1090
+  . "$WIGGUM_PATH"
 fi
-

--- a/version/0001/wiggum.sh
+++ b/version/0001/wiggum.sh
@@ -32,7 +32,7 @@ done
 
 
 # Check that Dockerfiles are alpha sorted
-if [ "$(ls *-Dockerfile 2> /dev/null | wc -l)" -ge "1" ];
+if [ "$(find . -type f -name "*-Dockerfile" 2> /dev/null | wc -l)" -ge "1" ];
 then
   COLLECTED_ERRORS+=("Dockerfile naming convention should be 'Dockerfile' or 'Dockerfile-<env>'")
 fi

--- a/version/0002/wiggum.sh
+++ b/version/0002/wiggum.sh
@@ -10,6 +10,7 @@ set -e
 echo "Wiggum is running..."
 COLLECTED_ERRORS=()
 
+# shellcheck disable=SC1091
 source .wiggum
 
 # Check that a README file exists
@@ -36,7 +37,7 @@ then
   done
 
   # Check that Dockerfiles are alpha sorted
-  if [ "$(ls *-Dockerfile 2> /dev/null | wc -l)" -ge "1" ];
+  if [ "$(find . -type f -name "*-Dockerfile" 2> /dev/null | wc -l)" -ge "1" ];
   then
     COLLECTED_ERRORS+=("Dockerfile naming convention should be 'Dockerfile', 'Dockerfile.<env>' or 'Dockerfile-<env>'")
   fi

--- a/version/0003/wiggum.sh
+++ b/version/0003/wiggum.sh
@@ -10,11 +10,12 @@ set -e
 echo "Wiggum is running..."
 COLLECTED_ERRORS=()
 
+# shellcheck disable=SC1091
 source .wiggum
 
 # root directory of the repository
 REPO_DIR="."
-# RELATIVE_PATH is the path to the infrastructure releated files. 
+# RELATIVE_PATH is the path to the infrastructure releated files.
 # default is the $REPO_DIR
 if [ -z "${RELATIVE_PATH}" ]; then
   RELATIVE_PATH=$REPO_DIR
@@ -34,7 +35,7 @@ fi
 # Check that Docker files are present with preferred naming convention
 if [[ -z "${CHECK_DOCKER}" ]] || [[ "${CHECK_DOCKER}" == "true" ]];
 then
-  DOCKER_SHOULD_EXIST=( ${RELATIVE_PATH}/Dockerfile ${RELATIVE_PATH}/docker-compose.yml ${RELATIVE_PATH}/.dockerignore  )
+  DOCKER_SHOULD_EXIST=( "${RELATIVE_PATH}/Dockerfile" "${RELATIVE_PATH}/docker-compose.yml" "${RELATIVE_PATH}/.dockerignore" )
   for i in "${DOCKER_SHOULD_EXIST[@]}"
   do
     if [ ! -f "$i" ];
@@ -44,7 +45,7 @@ then
   done
 
   # Check that Dockerfiles are alpha sorted
-  if [ "$(ls ${RELATIVE_PATH}/*-Dockerfile 2> /dev/null | wc -l)" -ge "1" ];
+  if [ "$(find . -type f -name "${RELATIVE_PATH}/*-Dockerfile" 2> /dev/null | wc -l)" -ge "1" ];
   then
     COLLECTED_ERRORS+=("Dockerfile naming convention should be 'Dockerfile', 'Dockerfile.<env>' or 'Dockerfile-<env>'")
   fi
@@ -73,7 +74,7 @@ then
   BUILDKITE_DIR="${RELATIVE_PATH}/.buildkite"
   BUILDKITE_FILE="pipeline.yml"
 
-  BUILDKITE_DIR_SHOULD_EXIST=( ${BUILDKITE_DIR} )
+  BUILDKITE_DIR_SHOULD_EXIST=( "${BUILDKITE_DIR}" )
   for i in "${BUILDKITE_DIR_SHOULD_EXIST[@]}"
   do
     if [ ! -d "$i" ];
@@ -81,7 +82,7 @@ then
       COLLECTED_ERRORS+=("Buildkite directory $i does not exist")
     fi
   done
-  BUILDKITE_SHOULD_EXIST=( ${BUILDKITE_DIR}/${BUILDKITE_FILE} )
+  BUILDKITE_SHOULD_EXIST=( "${BUILDKITE_DIR}/${BUILDKITE_FILE}" )
   for i in "${BUILDKITE_SHOULD_EXIST[@]}"
   do
     if [ ! -f "$i" ];
@@ -108,7 +109,7 @@ fi
 # Check that Terraform is present
 if [[ -z "${CHECK_TERRAFORM}" ]] || [[ "${CHECK_TERRAFORM}" == "true" ]];
 then
-  TERRAFORM_SHOULD_EXIST=( ${RELATIVE_PATH}/terraform )
+  TERRAFORM_SHOULD_EXIST=( "${RELATIVE_PATH}"/terraform )
   for i in "${TERRAFORM_SHOULD_EXIST[@]}"
   do
     if [ ! -d "$i" ];

--- a/version/0004/wiggum.sh
+++ b/version/0004/wiggum.sh
@@ -10,6 +10,7 @@ set -e
 echo "Wiggum is running..."
 COLLECTED_ERRORS=()
 
+# shellcheck disable=SC1091
 source .wiggum
 
 # root directory of the repository
@@ -34,7 +35,7 @@ fi
 # Check that Docker files are present with preferred naming convention
 if [[ -z "${CHECK_DOCKER}" ]] || [[ "${CHECK_DOCKER}" == "true" ]];
 then
-  DOCKER_SHOULD_EXIST=( ${RELATIVE_PATH}/Dockerfile ${RELATIVE_PATH}/docker-compose.yml ${RELATIVE_PATH}/.dockerignore  )
+  DOCKER_SHOULD_EXIST=( "${RELATIVE_PATH}/Dockerfile" "${RELATIVE_PATH}/docker-compose.yml" "${RELATIVE_PATH}/.dockerignore" )
   for i in "${DOCKER_SHOULD_EXIST[@]}"
   do
     if [ ! -f "$i" ];
@@ -44,7 +45,7 @@ then
   done
 
   # Check that Dockerfiles are alpha sorted
-  if [ "$(ls ${RELATIVE_PATH}/*-Dockerfile 2> /dev/null | wc -l)" -ge "1" ];
+  if [ "$(find . -type f -name "${RELATIVE_PATH}/*-Dockerfile" 2> /dev/null | wc -l)" -ge "1" ];
   then
     COLLECTED_ERRORS+=("Dockerfile naming convention should be 'Dockerfile', 'Dockerfile.<env>' or 'Dockerfile-<env>'")
   fi
@@ -76,7 +77,7 @@ then
   BUILDKITE_DIR="${RELATIVE_PATH}/.buildkite"
   BUILDKITE_FILE="pipeline.yml"
 
-  BUILDKITE_DIR_SHOULD_EXIST=( ${BUILDKITE_DIR} )
+  BUILDKITE_DIR_SHOULD_EXIST=( "${BUILDKITE_DIR}" )
   for i in "${BUILDKITE_DIR_SHOULD_EXIST[@]}"
   do
     if [ ! -d "$i" ];
@@ -84,7 +85,7 @@ then
       COLLECTED_ERRORS+=("Buildkite directory $i does not exist")
     fi
   done
-  BUILDKITE_SHOULD_EXIST=( ${BUILDKITE_DIR}/${BUILDKITE_FILE} )
+  BUILDKITE_SHOULD_EXIST=( "${BUILDKITE_DIR}/${BUILDKITE_FILE}" )
   for i in "${BUILDKITE_SHOULD_EXIST[@]}"
   do
     if [ ! -f "$i" ];
@@ -114,7 +115,7 @@ fi
 # Check that Terraform is present
 if [[ -z "${CHECK_TERRAFORM}" ]] || [[ "${CHECK_TERRAFORM}" == "true" ]];
 then
-  TERRAFORM_SHOULD_EXIST=( ${RELATIVE_PATH}/terraform )
+  TERRAFORM_SHOULD_EXIST=( "${RELATIVE_PATH}/terraform" )
   for i in "${TERRAFORM_SHOULD_EXIST[@]}"
   do
     if [ ! -d "$i" ];


### PR DESCRIPTION
Using [`shellcheck`](https://github.com/koalaman/shellcheck) for static analysis and detecting certain issues with bash scripts. It will be run as part of GitHub Actions pipeline.

Also addressed the problems reported by `shellcheck` as part of this PR.